### PR TITLE
Update link to mostly-adequate-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ store.dispatch(action(futureIo));
 ## Related
 
 ### What's an IO?
-* [mostly-adequate-guide  Chapter 8.5 Old McDonald had Effects...](https://drboolean.gitbooks.io/mostly-adequate-guide/content/ch8.html)
+* [mostly-adequate-guide  Chapter 8.5 Old McDonald had Effects...](https://drboolean.gitbooks.io/mostly-adequate-guide/content/ch8.html#old-mcdonald-had-effects)
 
 ### Libraries
 


### PR DESCRIPTION
This updates the link to chapter 8.5 instead of the beginning of chapter 8.
